### PR TITLE
Fixes readme import

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/sendgrid/sendlib-go/stopwatch"
+	"github.com/sendgrid/stopwatch"
 	"time"
 )
 


### PR DESCRIPTION
The sample import in README.md currently references sendlib-go, this needs to be fixed as we've moved stopwatch out of that package