### PR TITLE
Examples and tests have a racy result

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 go:
-- '1.0'
-- '1.3'
+  - 1.8
+script: go test -cover -bench=. -v -race ./...

--- a/example_test.go
+++ b/example_test.go
@@ -57,7 +57,7 @@ func ExampleMultiThread() {
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 2; i++ {
@@ -67,10 +67,9 @@ func ExampleMultiThread() {
 		}
 	}()
 
-	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Millisecond * 1100)
 		task := "task A"
 		sw.LapWithData(task, map[string]interface{}{
 			"filename": "word.doc",
@@ -91,5 +90,5 @@ func ExampleMultiThread() {
 	}
 
 	// Output:
-	// [{"state":"Create File","time":"0.0"},{"state":"task 0","time":"0.2"},{"state":"task 1","time":"0.2"},{"state":"Upload File","time":"0.6"},{"state":"task A","time":"0.0","filename":"word.doc"}]
+	// [{"state":"Create File","time":"0.0"},{"state":"task 0","time":"0.2"},{"state":"task 1","time":"0.2"},{"state":"Upload File","time":"0.6"},{"state":"task A","time":"0.1","filename":"word.doc"}]
 }

--- a/stopwatch_test.go
+++ b/stopwatch_test.go
@@ -109,7 +109,7 @@ func TestMultiThreadLaps(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 2; i++ {
@@ -119,10 +119,9 @@ func TestMultiThreadLaps(t *testing.T) {
 		}
 	}()
 
-	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Millisecond * 1100)
 		task := "task A"
 		sw.LapWithData(task, map[string]interface{}{
 			"filename": "word.doc",
@@ -145,7 +144,7 @@ func TestMultiThreadLaps(t *testing.T) {
 		{"task 0", "0.2"},
 		{"task 1", "0.2"},
 		{"Upload File", "0.6"},
-		{"task A", "0.0"},
+		{"task A", "0.1"},
 	}
 
 	laps := sw.Laps()


### PR DESCRIPTION
These racy results sometimes cause the test and the example to fail. Giving some more time between laps so that they should pass most of the time.