### PR TITLE
Race condition exists in Lap.String()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
 go:
-- '1.0'
-- '1.3'
+  - 1.8
+script: go test -cover -bench=. -v -race ./...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 ===========
+## 1.0.0
+- Breaking API change, by removing exported 'Formatter' variable
+- Fixes a race condition in the stopwatch involving Lap.String()
+
 ## 0.1.0
 - Added multi thread support
 

--- a/example_test.go
+++ b/example_test.go
@@ -57,7 +57,7 @@ func ExampleMultiThread() {
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 2; i++ {
@@ -67,10 +67,9 @@ func ExampleMultiThread() {
 		}
 	}()
 
-	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Millisecond * 1100)
 		task := "task A"
 		sw.LapWithData(task, map[string]interface{}{
 			"filename": "word.doc",
@@ -91,5 +90,5 @@ func ExampleMultiThread() {
 	}
 
 	// Output:
-	// [{"state":"Create File","time":"0.0"},{"state":"task 0","time":"0.2"},{"state":"task 1","time":"0.2"},{"state":"Upload File","time":"0.6"},{"state":"task A","time":"0.0","filename":"word.doc"}]
+	// [{"state":"Create File","time":"0.0"},{"state":"task 0","time":"0.2"},{"state":"task 1","time":"0.2"},{"state":"Upload File","time":"0.6"},{"state":"task A","time":"0.1","filename":"word.doc"}]
 }

--- a/example_test.go
+++ b/example_test.go
@@ -12,9 +12,9 @@ func ExampleSingleThread() {
 	sw := New(0, true)
 
 	// Optionally, format that time.Duration how you need it
-	sw.Formatter = func(duration time.Duration) string {
+	sw.SetFormatter(func(duration time.Duration) string {
 		return fmt.Sprintf("%.2f", duration.Seconds())
-	}
+	})
 
 	// Take measurement of various states
 	sw.Lap("Create File")
@@ -48,9 +48,9 @@ func ExampleMultiThread() {
 	sw := New(0, true)
 
 	// Optionally, format that time.Duration how you need it
-	sw.Formatter = func(duration time.Duration) string {
+	sw.SetFormatter(func(duration time.Duration) string {
 		return fmt.Sprintf("%.1f", duration.Seconds())
-	}
+	})
 
 	// Take measurement of various states
 	sw.Lap("Create File")

--- a/lap.go
+++ b/lap.go
@@ -7,19 +7,15 @@ import (
 )
 
 type Lap struct {
-	sw       *Stopwatch
-	state    string
-	duration time.Duration
-	data     map[string]interface{}
+	formatter func(time.Duration) string
+	sw        *Stopwatch
+	state     string
+	duration  time.Duration
+	data      map[string]interface{}
 }
 
 func (l Lap) String() string {
-	// No formatter defined, no problem use the default
-	if l.sw.Formatter == nil {
-		l.sw.Formatter = defaultFormatter
-	}
-
-	results := fmt.Sprintf("\"state\":\"%s\", \"time\":\"%s\"", l.state, l.sw.Formatter(l.duration))
+	results := fmt.Sprintf("\"state\":\"%s\", \"time\":\"%s\"", l.state, l.formatter(l.duration))
 
 	// If lap contains some data, let's merge it
 	if l.data != nil && len(l.data) > 0 {

--- a/stopwatch_test.go
+++ b/stopwatch_test.go
@@ -109,7 +109,7 @@ func TestMultiThreadLaps(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 2; i++ {
@@ -119,10 +119,9 @@ func TestMultiThreadLaps(t *testing.T) {
 		}
 	}()
 
-	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		time.Sleep(time.Second * 1)
+		time.Sleep(time.Millisecond * 1100)
 		task := "task A"
 		sw.LapWithData(task, map[string]interface{}{
 			"filename": "word.doc",
@@ -145,7 +144,7 @@ func TestMultiThreadLaps(t *testing.T) {
 		{"task 0", "0.2"},
 		{"task 1", "0.2"},
 		{"Upload File", "0.6"},
-		{"task A", "0.0"},
+		{"task A", "0.1"},
 	}
 
 	laps := sw.Laps()

--- a/stopwatch_test.go
+++ b/stopwatch_test.go
@@ -160,3 +160,12 @@ func TestMultiThreadLaps(t *testing.T) {
 		}
 	}
 }
+
+func TestPrintLaps(t *testing.T) {
+	sw := New(0, true)
+	sw.Lap("lap1")
+	sw.Lap("lap2")
+	laps := sw.Laps()
+	go laps[0].String()
+	go laps[1].String()
+}


### PR DESCRIPTION
Due to the attempt to initialize the formatter with defaultFormatter.

My fix to this race, was an API change to remove the exposed variable of "Formatter". Instead, upon creation, each Lap instance gets it's own reference to a formatter function.

So I bumped the major version to support this breaking API change.