### PR TITLE
Deterministic fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
 go:
   - 1.8
+  - 1.9
+  - 1.10
+  - tip
 script: go test -cover -bench=. -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.8
-  - 1.9
-  - 1.10
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
   - tip
 script: go test -cover -bench=. -v -race ./...

--- a/example_test.go
+++ b/example_test.go
@@ -3,6 +3,7 @@ package stopwatch
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 )
@@ -42,7 +43,7 @@ func ExampleStopwatch_multiThread() {
 
 	// Optionally, format that time.Duration how you need it
 	sw.SetFormatter(func(duration time.Duration) string {
-		return fmt.Sprintf("%.1f", duration.Seconds())
+		return fmt.Sprintf("%.0f", duration.Seconds())
 	})
 
 	// Take measurement of various states
@@ -54,7 +55,6 @@ func ExampleStopwatch_multiThread() {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 2; i++ {
-			time.Sleep(time.Millisecond * 200)
 			task := fmt.Sprintf("task %d", i)
 			sw.Lap(task)
 		}
@@ -62,7 +62,6 @@ func ExampleStopwatch_multiThread() {
 
 	go func() {
 		defer wg.Done()
-		time.Sleep(time.Millisecond * 1100)
 		task := "task A"
 		sw.LapWithData(task, map[string]interface{}{
 			"filename": "word.doc",
@@ -70,18 +69,26 @@ func ExampleStopwatch_multiThread() {
 	}()
 
 	// Simulate some time by sleeping
-	time.Sleep(time.Second * 1)
 	sw.Lap("Upload File")
 
 	// Stop the timer
 	wg.Wait()
 	sw.Stop()
 
-	// Marshal to json
-	if b, err := json.Marshal(sw); err == nil {
-		fmt.Println(string(b))
+	laps := sw.Laps()
+	sorted := make([]string, 0, len(laps))
+	for _, lap := range laps {
+		sorted = append(sorted, lap.String())
+	}
+	sort.Strings(sorted)
+	for _, lap := range sorted {
+		fmt.Println(lap)
 	}
 
 	// Output:
-	// [{"state":"Create File","time":"0.0"},{"state":"task 0","time":"0.2"},{"state":"task 1","time":"0.2"},{"state":"Upload File","time":"0.6"},{"state":"task A","time":"0.1","filename":"word.doc"}]
+	// {"state":"Create File", "time":"0"}
+	// {"state":"Upload File", "time":"0"}
+	// {"state":"task 0", "time":"0"}
+	// {"state":"task 1", "time":"0"}
+	// {"state":"task A", "time":"0", "filename":"word.doc"}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -13,21 +13,14 @@ func ExampleStopwatch_singleThread() {
 
 	// Optionally, format that time.Duration how you need it
 	sw.SetFormatter(func(duration time.Duration) string {
-		return fmt.Sprintf("%.2f", duration.Seconds())
+		return fmt.Sprintf("%.0f", duration.Seconds())
 	})
 
 	// Take measurement of various states
 	sw.Lap("Create File")
-
-	// Simulate some time by sleeping
-	time.Sleep(time.Millisecond * 300)
 	sw.Lap("Edit File")
-
-	time.Sleep(time.Second * 1)
 	sw.Lap("Upload File")
-
 	// Take a measurement with some additional metadata
-	time.Sleep(time.Millisecond * 20)
 	sw.LapWithData("Delete File", map[string]interface{}{
 		"filename": "word.doc",
 	})
@@ -39,8 +32,8 @@ func ExampleStopwatch_singleThread() {
 	if b, err := json.Marshal(sw); err == nil {
 		fmt.Println(string(b))
 	}
-	// Expected Output (may not exactly match):
-	// [{"state":"Create File","time":"0.00"},{"state":"Edit File","time":"0.30"},{"state":"Upload File","time":"1.00"},{"state":"Delete File","time":"0.02","filename":"word.doc"}]
+	// Output:
+	// [{"state":"Create File","time":"0"},{"state":"Edit File","time":"0"},{"state":"Upload File","time":"0"},{"state":"Delete File","time":"0","filename":"word.doc"}]
 }
 
 func ExampleStopwatch_multiThread() {

--- a/lap.go
+++ b/lap.go
@@ -17,13 +17,12 @@ func (l Lap) String() string {
 	results := fmt.Sprintf("\"state\":\"%s\", \"time\":\"%s\"", l.state, l.formatter(l.duration))
 
 	// If lap contains some data, let's merge it
-	if l.data != nil && len(l.data) > 0 {
+	if len(l.data) > 0 {
 		items := make([]string, 0)
 		for k, v := range l.data {
 			items = append(items, fmt.Sprintf("\"%s\":\"%s\"", k, v))
 		}
 		return fmt.Sprintf("{%s, %s}", results, strings.Join(items, ", "))
-
 	}
 
 	// Otherwise, we just record the lap, and duration

--- a/lap.go
+++ b/lap.go
@@ -8,7 +8,6 @@ import (
 
 type Lap struct {
 	formatter func(time.Duration) string
-	sw        *Stopwatch
 	state     string
 	duration  time.Duration
 	data      map[string]interface{}

--- a/stopwatch.go
+++ b/stopwatch.go
@@ -86,7 +86,7 @@ func (s *Stopwatch) Start() {
 	s.Lock()
 	defer s.Unlock()
 	if !s.active() {
-		diff := time.Now().Sub(s.stop)
+		diff := time.Since(s.stop)
 		s.start = s.start.Add(diff)
 		s.stop = time.Time{}
 	}

--- a/stopwatch_test.go
+++ b/stopwatch_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestLaps(t *testing.T) {
+	t.Parallel()
 	sw := New(0, true)
 
 	sw.Lap("Session Create")
@@ -37,6 +38,7 @@ func TestLaps(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
+	t.Parallel()
 	sw := New(0, true)
 
 	sw.Lap("Session Create")
@@ -67,6 +69,7 @@ func TestReset(t *testing.T) {
 }
 
 func TestMultiThreadLaps(t *testing.T) {
+	t.Parallel()
 	// Create a new StopWatch that starts off counting
 	sw := New(0, true)
 
@@ -127,6 +130,7 @@ func TestMultiThreadLaps(t *testing.T) {
 }
 
 func TestPrintLaps(t *testing.T) {
+	t.Parallel()
 	sw := New(0, true)
 	sw.Lap("lap1")
 	sw.Lap("lap2")
@@ -136,6 +140,7 @@ func TestPrintLaps(t *testing.T) {
 }
 
 func TestLapTime(t *testing.T) {
+	t.Parallel()
 	sw := New(0, true)
 	sw.Start()
 	laptime1 := sw.LapTime()
@@ -146,6 +151,7 @@ func TestLapTime(t *testing.T) {
 }
 
 func TestInactiveStart(t *testing.T) {
+	t.Parallel()
 	sw := New(0, false)
 	sw.Start()
 	sw.Lap("running lap")

--- a/stopwatch_test.go
+++ b/stopwatch_test.go
@@ -2,22 +2,15 @@ package stopwatch
 
 import (
 	"fmt"
-	"math"
 	"sync"
 	"testing"
-	"time"
 )
 
 func TestLaps(t *testing.T) {
 	sw := New(0, true)
 
-	time.Sleep(time.Millisecond * 100)
 	sw.Lap("Session Create")
-
-	time.Sleep(time.Millisecond * 250)
 	sw.Lap("Delete File")
-
-	time.Sleep(time.Millisecond * 300)
 	sw.LapWithData("Close DB", map[string]interface{}{
 		"row_count": 2,
 	})
@@ -26,21 +19,13 @@ func TestLaps(t *testing.T) {
 		t.Fatalf("Created 3 laps but found %d laps.", len(sw.Laps()))
 	}
 
-	expected := []struct {
-		state    string
-		duration string
-	}{
-		{"Session Create", "100"},
-		{"Delete File", "250"},
-		{"Close DB", "300"},
-	}
+	expected := []string{"Session Create", "Delete File", "Close DB"}
 
 	laps := sw.Laps()
 
-	for i, l := range expected {
-		if l.state != laps[i].state ||
-			l.duration != fmt.Sprintf("%d", int(math.Floor(100*laps[i].duration.Seconds())*10)) {
-			t.Fatalf("Lap %d did not contain expected state: %s and/or duration: %s", i, l.state, l.duration)
+	for i, state := range expected {
+		if state != laps[i].state {
+			t.Fatalf("Lap %d did not contain expected state: %s", i, state)
 		}
 	}
 
@@ -54,43 +39,29 @@ func TestLaps(t *testing.T) {
 func TestReset(t *testing.T) {
 	sw := New(0, true)
 
-	time.Sleep(time.Millisecond * 100)
 	sw.Lap("Session Create")
 
-	expected := []struct {
-		state    string
-		duration string
-	}{
-		{"Session Create", "100"},
-	}
+	expected := []string{"Session Create"}
 
 	laps := sw.Laps()
 
-	for i, l := range expected {
-		if l.state != laps[i].state ||
-			l.duration != fmt.Sprintf("%d", int(math.Floor(100*laps[i].duration.Seconds())*10)) {
-			t.Fatalf("Lap %d did not contain expected state: %s and/or duration: %s", i, l.state, l.duration)
+	for i, state := range expected {
+		if state != laps[i].state {
+			t.Fatalf("Lap %d did not contain expected state: %s", i, state)
 		}
 	}
 
 	sw.Reset(0, true)
 
-	time.Sleep(time.Millisecond * 200)
 	sw.Lap("Another Session Create")
 
-	expected = []struct {
-		state    string
-		duration string
-	}{
-		{"Another Session Create", "200"},
-	}
+	expected = []string{"Another Session Create"}
 
 	laps = sw.Laps()
 
-	for i, l := range expected {
-		if l.state != laps[i].state ||
-			l.duration != fmt.Sprintf("%d", int(math.Floor(100*laps[i].duration.Seconds())*10)) {
-			t.Fatalf("Lap %d did not contain expected state: %s and/or duration: %s", i, l.state, l.duration)
+	for i, state := range expected {
+		if state != laps[i].state {
+			t.Fatalf("Lap %d did not contain expected state: %s", i, state)
 		}
 	}
 }
@@ -113,7 +84,6 @@ func TestMultiThreadLaps(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 2; i++ {
-			time.Sleep(time.Millisecond * 200)
 			task := fmt.Sprintf("task %d", i)
 			sw.Lap(task)
 		}
@@ -121,7 +91,6 @@ func TestMultiThreadLaps(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		time.Sleep(time.Millisecond * 1100)
 		task := "task A"
 		sw.LapWithData(task, map[string]interface{}{
 			"filename": "word.doc",
@@ -129,34 +98,30 @@ func TestMultiThreadLaps(t *testing.T) {
 	}()
 
 	// Simulate some time by sleeping
-	time.Sleep(time.Second * 1)
 	sw.Lap("Upload File")
 
 	// Stop the timer
 	wg.Wait()
 	sw.Stop()
 
-	expected := []struct {
-		state    string
-		duration string
-	}{
-		{"Create File", "0.0"},
-		{"task 0", "0.2"},
-		{"task 1", "0.2"},
-		{"Upload File", "0.6"},
-		{"task A", "0.1"},
+	expected := map[string]struct{}{
+		"Create File": struct{}{},
+		"task 0":      struct{}{},
+		"task 1":      struct{}{},
+		"Upload File": struct{}{},
+		"task A":      struct{}{},
 	}
 
 	laps := sw.Laps()
 
-	for i, l := range expected {
-		duration := fmt.Sprintf("%.1f", laps[i].duration.Seconds())
-		if l.state != laps[i].state ||
-			l.duration != duration {
-			t.Fatalf(
-				"Lap %d: got state: %s, duration: %s. expected state: %s and/or duration: %s",
-				i, laps[i].state, duration, l.state, l.duration,
-			)
+	if len(laps) != len(expected) {
+		t.Fatalf("Did not get the expected number of lap %d, instead got %d",
+			len(expected), len(laps))
+	}
+
+	for i, l := range laps {
+		if _, found := expected[l.state]; !found {
+			t.Fatalf("Lap %d: got state: %s expected state: %s", i, laps[i].state, l.state)
 		}
 	}
 }
@@ -173,12 +138,10 @@ func TestPrintLaps(t *testing.T) {
 func TestLapTime(t *testing.T) {
 	sw := New(0, true)
 	sw.Start()
-	time.Sleep(100 * time.Millisecond)
 	laptime1 := sw.LapTime()
-	time.Sleep(100 * time.Millisecond)
 	laptime2 := sw.LapTime()
-	if diff := laptime2.Seconds() - laptime1.Seconds(); diff < 0.1 {
-		t.Errorf("LapTime should be at least 100 milliseconds apart")
+	if diff := laptime2.Nanoseconds() - laptime1.Nanoseconds(); diff <= 0 {
+		t.Errorf("LapTime difference should be greater than zero")
 	}
 }
 

--- a/stopwatch_test.go
+++ b/stopwatch_test.go
@@ -100,9 +100,9 @@ func TestMultiThreadLaps(t *testing.T) {
 	sw := New(0, true)
 
 	// Optionally, format that time.Duration how you need it
-	//	sw.Formatter = func(duration time.Duration) string {
+	//	sw.SetFormatter(func(duration time.Duration) string {
 	//		return fmt.Sprintf("%.1f", duration.Seconds())
-	//	}
+	//	})
 
 	// Take measurement of various states
 	sw.Lap("Create File")


### PR DESCRIPTION
These fixes should provide deterministic builds.

Things fixed in this PR
1. Remove redundant nil check, because "len()" is valid on nil slice reference.
1. ExampleSingleThread was not running because the Output line format wasn't correct.
1. Remove instances of time.Sleep so that tests can run quickly and deterministically.
1. Remove an unused reference to "sw *Stopwatch" in the Lap struct.
