### PR TITLE
go vet fixes

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-func ExampleSingleThread() {
+func ExampleStopwatch_singleThread() {
 	// Create a new StopWatch that starts off counting
 	sw := New(0, true)
 
@@ -43,7 +43,7 @@ func ExampleSingleThread() {
 	// [{"state":"Create File","time":"0.00"},{"state":"Edit File","time":"0.30"},{"state":"Upload File","time":"1.00"},{"state":"Delete File","time":"0.02","filename":"word.doc"}]
 }
 
-func ExampleMultiThread() {
+func ExampleStopwatch_multiThread() {
 	// Create a new StopWatch that starts off counting
 	sw := New(0, true)
 

--- a/stopwatch_test.go
+++ b/stopwatch_test.go
@@ -23,7 +23,7 @@ func TestLaps(t *testing.T) {
 	})
 
 	if len(sw.Laps()) != 3 {
-		t.Fatal("Created 3 laps but found %d laps.", len(sw.Laps()))
+		t.Fatalf("Created 3 laps but found %d laps.", len(sw.Laps()))
 	}
 
 	expected := []struct {


### PR DESCRIPTION
```
stopwatch [master u=]: go vet ./...
example_test.go:10: ExampleSingleThread refers to unknown identifier: SingleThread
example_test.go:46: ExampleMultiThread refers to unknown identifier: MultiThread
stopwatch_test.go:26: possible formatting directive in Fatal call
exit status 1
```
The example function names have a suffix to distinguish 'singleThread' and 'multiThread'.

Also, use Fatalf, not Fatal for a formatted string.